### PR TITLE
Add @family type tags for atlas classification

### DIFF
--- a/R/chen.R
+++ b/R/chen.R
@@ -4,6 +4,7 @@
 #' per hemisphere based on Chen et al. (2013).
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Chen C-H, et al. (2013).
 #'   Genetic topography of brain morphology.
@@ -23,6 +24,7 @@ chenAr <- function() .chenAr
 #' regions per hemisphere based on Chen et al. (2013).
 #'
 #' @family ggseg_atlases
+#' @family cortical_atlases
 #'
 #' @references Chen C-H, et al. (2013).
 #'   Genetic topography of brain morphology.

--- a/man/chenAr.Rd
+++ b/man/chenAr.Rd
@@ -25,5 +25,9 @@ Chen C-H, et al. (2013).
 \seealso{
 Other ggseg_atlases: 
 \code{\link{chenTh}()}
+
+Other cortical_atlases: 
+\code{\link{chenTh}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}

--- a/man/chenTh.Rd
+++ b/man/chenTh.Rd
@@ -25,5 +25,9 @@ Chen C-H, et al. (2013).
 \seealso{
 Other ggseg_atlases: 
 \code{\link{chenAr}()}
+
+Other cortical_atlases: 
+\code{\link{chenAr}()}
 }
+\concept{cortical_atlases}
 \concept{ggseg_atlases}


### PR DESCRIPTION
## Summary
- Add `@family cortical_atlases` / `@family subcortical_atlases` type tags to atlas roxygen docs
- Regenerate Rd files with `\concept{}` entries

These tags enable downstream tools to classify atlases by type (cortical, subcortical, cerebellar, etc.).

## Test plan
- [ ] R CMD check passes
- [ ] `\concept{}` tags present in generated Rd files

🤖 Generated with [Claude Code](https://claude.com/claude-code)